### PR TITLE
Fix duplicate roots for separate transforms

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -55,7 +55,8 @@ const attacher: unifiedTypes.Plugin<
         parsedOutput.children.find(
           (child) => child.type === "element"
         )!.position = node.position;
-        parent.children[index] = parsedOutput;
+        parent.children.splice(index, 1, ...parsedOutput.children);
+        return index + parsedOutput.children.length;
       }
     })(tree as any);
   };


### PR DESCRIPTION
It seems that performing two separate `unified` passes currently causes duplicate root nodes (e.g. `{ type: 'root' }` as a child of the top-level root) when an AST from a prior transform is used with this plugin.

I was able to fix it by adding the parsed output's children individually rather than adding the root parsed output node. I've also confirmed that the newly added test fails before the change and passes with the change.